### PR TITLE
fix: Resolver cache will trigger re-evaluation even on startup failure

### DIFF
--- a/oidf-services/src/main/java/se/swedenconnect/oidf/service/state/RegistryStateManager.java
+++ b/oidf-services/src/main/java/se/swedenconnect/oidf/service/state/RegistryStateManager.java
@@ -71,9 +71,12 @@ public class RegistryStateManager extends ReadyStateComponent {
    */
   @EventListener
   public RegistryReadyEvent init(final ApplicationStartedEvent event) {
-    this.reloadFromRegistry();
-    this.markReady();
-    return new RegistryReadyEvent();
+    try {
+      this.reloadFromRegistry();
+      return new RegistryReadyEvent();
+    } finally {
+      this.markReady();
+    }
   }
 
   /**

--- a/oidf-services/src/main/java/se/swedenconnect/oidf/service/state/ResolverStateManager.java
+++ b/oidf-services/src/main/java/se/swedenconnect/oidf/service/state/ResolverStateManager.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import se.swedenconnect.oidf.service.error.ErrorHandler;
 import se.swedenconnect.oidf.service.health.ReadyStateComponent;
 import se.swedenconnect.oidf.service.resolver.cache.CompositeTreeLoader;
 
@@ -62,7 +63,7 @@ public class ResolverStateManager extends ReadyStateComponent {
   }
 
   /**
-   * Trigger reload of this component if needed.
+   * Trigger reload of this component.
    */
   @Scheduled(fixedRate = 60, timeUnit = TimeUnit.MINUTES)
   public void reload() {
@@ -74,8 +75,11 @@ public class ResolverStateManager extends ReadyStateComponent {
 
   @EventListener
   void handle(final RegistryReadyEvent event) {
-    this.reloadResolvers();
-    this.markReady();
+    try {
+      this.reloadResolvers();
+    } finally {
+      this.markReady();
+    }
   }
 
   @EventListener


### PR DESCRIPTION
Closes #102 